### PR TITLE
Add Mac support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # Backblaze Exclusion Manager
-A small windows program to fine tune exclusion list for backblaze personal backup. 
-Exclude files or folders from being backed up and eating up your previous bandwidth.
+A small Python program to fine tune exclusion list for Backblaze personal backup. 
+Exclude files or folders from being backed up and eating up your precious bandwidth.
 
 ![image](https://github.com/user-attachments/assets/d3cec3e3-be51-4862-93a7-1726df7b571b)
 
 ## How to use
 1. Use the buttons to select file or a folder.
-2. To remove something from the exclusion list, select it from the list and click the "Remove Selected" button. This will promp a dialog box asking you confirm your action. This is undoable.
+2. To remove something from the exclusion list, select it from the list and click the "Remove Selected" button. This will prompt a dialog box asking you confirm your action. This is undoable.
 3. You can backup the xml file that these entries is being written into. The backup will copy the same file and save it with extension .xml_DDMMYYhhmmss where the suffix is the date and time.
 4. Always a good idea to remove all extensions from the default exclusion list like this in backblaze control panel. ![image](https://github.com/user-attachments/assets/b4bfd9fd-c96c-4e09-8f51-a9c8a86b6eb1)
 
@@ -34,4 +34,3 @@ Backblaze does allow you to manually edit exclusion list using an xml file (Arti
 2. Not affliated with Backblaze or Backblaze, Inc.
 3. Run as administrator to avoid problems. (Optional)
 4. Always a good idea to create backups of the default xml list before making any edits.
-5. Created for Windows and tested on Windows. I do not recommend using the python script to run this program on a mac, unless specifically modified to be used on mac.

--- a/gui.py
+++ b/gui.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from datetime import datetime
 import shutil
 
+
 class ExclusionManagerGUI:
     def __init__(self):
         self.root = ctk.CTk()
@@ -38,20 +39,20 @@ class ExclusionManagerGUI:
 
         # Create buttons
         ctk.CTkButton(self.button_frame,
-                     text="Select File",
-                     command=self.select_file).pack(side="left", padx=5, pady=5, expand=True)
+                      text="Select File",
+                      command=self.select_file).pack(side="left", padx=5, pady=5, expand=True)
 
         ctk.CTkButton(self.button_frame,
-                     text="Select Folder",
-                     command=self.select_folder).pack(side="left", padx=5, pady=5, expand=True)
+                      text="Select Folder",
+                      command=self.select_folder).pack(side="left", padx=5, pady=5, expand=True)
 
         ctk.CTkButton(self.button_frame,
-                     text="Remove Selected",
-                     command=self.remove_selected).pack(side="left", padx=5, pady=5, expand=True)
+                      text="Remove Selected",
+                      command=self.remove_selected).pack(side="left", padx=5, pady=5, expand=True)
 
         ctk.CTkButton(self.button_frame,
-                     text="Backup This List",
-                     command=self.create_backup).pack(side="left", padx=5, pady=5, expand=True)
+                      text="Backup This List",
+                      command=self.create_backup).pack(side="left", padx=5, pady=5, expand=True)
 
         # Create scrollable frame for list
         self.list_frame = ctk.CTkScrollableFrame(self.main_frame)
@@ -64,7 +65,7 @@ class ExclusionManagerGUI:
         # Load existing entries
         self.refresh_listbox()
 
-    def handle_label_click(self, label, text):
+    def handle_label_click(self, label):
         if self.selected_label:
             self.selected_label.configure(fg_color="transparent")
         label.configure(fg_color="green")
@@ -128,26 +129,11 @@ class ExclusionManagerGUI:
                     cursor="hand2"
                 )
                 label.pack(fill="x", padx=5, pady=2)
-                label.bind("<Button-1>", lambda e, l=label, t=entry: self.handle_label_click(l, t))
+                label.bind("<Button-1>", lambda event, widget=label: self.handle_label_click(widget))
                 self.labels.append(label)
 
         except Exception as e:
             messagebox.showerror("Error", f"Error loading existing entries: {str(e)}")
-
-    def handle_click(self, event):
-        # Get clicked position
-        index = self.listbox.index(f"@{event.x},{event.y}")
-        line = int(index.split('.')[0])
-
-        # Clear previous selection
-        self.listbox.configure(state="normal")
-        self.listbox.tag_remove("selected", "1.0", "end")
-
-        # Add new selection
-        self.listbox.tag_add("selected", f"{line}.0", f"{line + 1}.0")
-        self.selected_line = line
-
-        self.listbox.configure(state="disabled")
 
     def get_selected_text(self):
         if not self.selected_label:
@@ -157,26 +143,6 @@ class ExclusionManagerGUI:
         text = self.selected_label.cget("text")
         # Remove the number prefix
         return '.'.join(text.split('.')[1:]).strip()
-
-    def get_selected_line(self):
-        if self.selected_line is None:
-            messagebox.showinfo("Info", "Please select an item first")
-            return None
-
-        try:
-            # Get the text of the selected line
-            self.listbox.configure(state="normal")
-            line_start = f"{self.selected_line}.0"
-            line_end = f"{self.selected_line}.end"
-            selected_text = self.listbox.get(line_start, line_end).strip()
-            self.listbox.configure(state="disabled")
-
-            # Remove the line number prefix
-            if selected_text:
-                selected_text = '.'.join(selected_text.split('.')[1:]).strip()
-            return selected_text
-        except:
-            return None
 
     def create_exclusion_rule(self, path, is_file=False):
         base_rule = {
@@ -303,7 +269,6 @@ class ExclusionManagerGUI:
         except Exception as e:
             messagebox.showerror("Error", f"Error removing entry: {str(e)}")
 
-
     def create_backup(self):
         try:
             # Generate timestamp in ddmmyyhhmmss format
@@ -318,6 +283,7 @@ class ExclusionManagerGUI:
 
     def run(self):
         self.root.mainloop()
+
 
 if __name__ == "__main__":
     app = ExclusionManagerGUI()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+customtkinter~=5.2.2


### PR DESCRIPTION
Only show rules applying to current platform; set `plat` attribute correctly when creating a rule.

If running on Mac:
* Use correct location for `bzexcluderules_editable.xml`
* Do not change slashes in selected file and folder paths

Also:
* Added `requirements.txt`
* Removed unused parameter and unreachable code. 
* Minor format corrections.